### PR TITLE
General feed improvements

### DIFF
--- a/sermon.ts
+++ b/sermon.ts
@@ -127,10 +127,19 @@ export function convertSermonToEpisode(sermon: Sermon): Episode {
     })();
 
     const title = (() => {
-        if (passageSummary != null) {
-            return `${sermon.title} – ${passageSummary}`;
+        if (passageSummary == null) {
+            return sermon.title;
         }
-        return sermon.title;
+        if (
+            passageSummary.toLocaleLowerCase() ===
+            sermon.title.toLocaleLowerCase()
+        ) {
+            // Occasionally they are identical. While it'd be better to fix
+            // the underlying data, this isn't always practical so this is
+            // a reasonable compromise.
+            return sermon.title;
+        }
+        return `${sermon.title} – ${passageSummary}`;
     })();
     return {
         title,

--- a/sermon.ts
+++ b/sermon.ts
@@ -27,7 +27,6 @@ export type Sermon = {
     preachedAt: string;
     duration: number;
     link: string;
-    imageUrl?: string;
     author: string;
     event: string;
 };
@@ -81,7 +80,6 @@ export function convertSermonToEpisode(sermon: Sermon): Episode {
         title,
         mediaUrl: sermon.link,
         description: description,
-        imageUrl: sermon.imageUrl,
         author: sermon.author,
         durationInSeconds: sermon.duration,
         releaseDate: sermon.preachedAt,


### PR DESCRIPTION
- Various fixes associated with invalid assumptions about shape of SanitySermon:
  - Gracefully handle no durationInSeconds (default to 30mins)
  - Actually extract the passage property now (previously was being completely ignored)
  - Various other graceful handling of null properties, remove some assumptions that arrays always have exactly 1 element
- Beefier podcast description – now has info about speaker, service, etc